### PR TITLE
Fix trailing and/or prefixed whitespace

### DIFF
--- a/lib/detik.bash
+++ b/lib/detik.bash
@@ -127,7 +127,7 @@ verify() {
 
 		echo "Valid expression. Verification in progress..."
 		query=$(build_k8s_request "")
-		result=$(eval $DETIK_CLIENT_NAME get $resource $query | grep $name | tail -n +1 | wc -l)
+		result=$(eval $DETIK_CLIENT_NAME get $resource $query | grep $name | tail -n +1 | wc -l | tr -d '[:space:]')
 
 		detik_debug "----DETIK-----"
 		detik_debug "$BATS_TEST_FILENAME"


### PR DESCRIPTION
When doing some basic tests for namespaces, all detik tests failed on my machine. This was due to some strange whitespace prefixing of the kubectl result:

```
╰─ cat /tmp/detik/namespaces.bats.debug
----DETIK-----
.../tests/./namespaces.bats
Namespaces

Client query:
kubectl get namespace -o custom-columns=NAME:.metadata.name

Result:
       1
----DETIK-----
Command output is: Valid expression. Verification in progress...
Found        1 namespace named kube-monitoring (instead of 1 expected).
```

This PR removes whitespace from the result.