### PR TITLE
Return early when result is empty in verify_value

### DIFF
--- a/lib/detik.bash
+++ b/lib/detik.bash
@@ -216,6 +216,7 @@ verify_value() {
 	empty=0
 	if [[ "$result" == "" ]]; then
 		echo "No resource of type '$resource' was found with the name '$name'."
+		return 101
 	fi
 
 	# Verify the result


### PR DESCRIPTION
When the result is empty in an assertion, `verify_value` returns 0, which causes the test to succeed when it should fail. The test I used for this was 
``` 
run verify "'status' is 'running' for pods named 'app'"
```

When that pod doesn't exist prior to this change, the test would succeed.