### PR TITLE
Fix "try" not retrying when assertion fails

### DIFF
--- a/lib/detik.bash
+++ b/lib/detik.bash
@@ -73,8 +73,7 @@ try() {
 		for ((i=1; i<=$times; i++)); do
 
 			# Verify the value
-			verify_value $property $expected_value $resource $name "$expected_count"
-			code=$?
+			verify_value $property $expected_value $resource $name "$expected_count" && code=$? || code=$?
 
 			# Break the loop prematurely?
 			if [[ "$code" == "0" ]]; then


### PR DESCRIPTION
With bash's `errexit` is enabled, `code=$?` is never reached when the `verify_value` command fails with non-zero exit code. This should fix it and actually cause detik to retry until the resource has the expected status. Otherwise it would just fail at first try and thus be pointless when trying to wait for a Pod