### PR TITLE
Add load.bash helper for standardized includes

### DIFF
--- a/load.bash
+++ b/load.bash
@@ -1,0 +1,3 @@
+source "$(dirname "${BASH_SOURCE[0]}")/lib/utils.bash"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/detik.bash"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/linter.bash"


### PR DESCRIPTION
This makes it easier to include the library with bats_load_library:

> bats_load_library has two modes of resolving requests:
> by relative path from the BATS_LIB_PATH to a file in the library
> by library name, expecting libraries to have a load.bash entrypoint

https://bats-core.readthedocs.io/en/stable/writing-tests.html#bats-load-library-load-system-wide-libraries

Closes https://github.com/bats-core/bats-detik/issues/52